### PR TITLE
Update tests to check for redirection to dashboard

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
     delete 'logout', to: 'users/sessions#destroy'
     post 'logout', to: 'users/sessions#destroy'
     get '/', to: 'users/sessions#default'
+    if Rails.env == "test"
+      # Dashboard app may not be available when testing, so spoof it
+      get "/dashboard", to: 'users/sessions#default'
+    end
   end
 
   devise_for :users, controllers: { sessions: 'users/sessions' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     delete 'logout', to: 'users/sessions#destroy'
     post 'logout', to: 'users/sessions#destroy'
     get '/', to: 'users/sessions#default'
-    if Rails.env == "test"
+    if Rails.env.test?
       # Dashboard app may not be available when testing, so spoof it
       get "/dashboard", to: 'users/sessions#default'
     end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe User, type: :feature do
       it "redirects to the default URL" do
         visit "/login"
         submit_form
-        expect(current_path).to eq("/")
+        expect(current_path).to eq("/dashboard")
       end
     end
   end
@@ -35,7 +35,7 @@ RSpec.describe User, type: :feature do
         visit "/login"
         submit_form
         visit "/login"
-        expect(current_path).to eq("/")
+        expect(current_path).to eq("/dashboard")
       end
     end
 


### PR DESCRIPTION
Tests were failing due to my earlier change that would redirect people to the Aker dashboard (if they were logging in without a redirect URL provided). I've spoofed the dashboard when in the test environment, but I'm not sure if this is the best approach.